### PR TITLE
[feat] Dressroom 페이지 구현

### DIFF
--- a/src/app/api/dressroom/[url]/route.ts
+++ b/src/app/api/dressroom/[url]/route.ts
@@ -5,6 +5,7 @@ export async function GET(
   { params }: { params: { url: string } },
 ) {
   const startTime = Date.now();
+
   try {
     const decodedUrl = decodeURIComponent(params.url);
 
@@ -35,7 +36,7 @@ export async function GET(
         productCategoryElement
       ) {
         return {
-          site: window.location.href,
+          site: decodedUrl,
           name: productNameElement.textContent?.trim(),
           image: (productImageElement as HTMLImageElement).src,
           price: parseInt(

--- a/src/app/dressroom/layout.tsx
+++ b/src/app/dressroom/layout.tsx
@@ -6,9 +6,9 @@ export default function Layout({
   dressroomModal: React.ReactNode;
 }) {
   return (
-    <section>
+    <>
       {children}
       {dressroomModal}
-    </section>
+    </>
   );
 }

--- a/src/app/dressroom/page.tsx
+++ b/src/app/dressroom/page.tsx
@@ -1,6 +1,5 @@
-import { BasicButton, TagButton } from "@/components/atoms";
+import { DressroomContent } from "@/components/organism";
 import { getOneUser } from "@/lib/api";
-import Image from "next/image";
 
 const Page = async () => {
   const userId = "667c2764df7a458908b4b54b";
@@ -9,55 +8,8 @@ const Page = async () => {
 
   return (
     <main className="my-20 flex w-full px-[85px]">
-      <aside className="w-[300px]">filter</aside>
-      <section className="flex w-full flex-col">
-        <div className="mb-[38px] flex justify-between">
-          <div className="flex gap-3">
-            <TagButton color="secondary">최신순</TagButton>
-            <TagButton color="secondary">업로드순</TagButton>
-            <TagButton color="secondary">가다나순</TagButton>
-            <TagButton color="secondary">낮은 가격순</TagButton>
-            <TagButton color="secondary">높은 가격순</TagButton>
-          </div>
-          <div className="flex gap-3">
-            <BasicButton
-              className="px-4"
-              size="sm"
-              color="primary"
-              href="/dressroom/register"
-            >
-              등록
-            </BasicButton>
-            <BasicButton className="px-4" size="sm" color="primary" href="#">
-              편집
-            </BasicButton>
-          </div>
-        </div>
-        <ul className="grid w-full grid-cols-5 gap-5">
-          {dressroom.map((item) => (
-            <li
-              className="group relative block aspect-square shadow-lg"
-              key={item._id}
-            >
-              <div className="absolute inset-0 z-10 flex flex-col justify-end bg-hover-gradient px-5 pb-4 text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
-                <span className="truncate text-b-2-bold">{item.name}</span>
-                <span className="mb-3 text-b-3-regular text-gray-200">
-                  {item.price}원
-                </span>
-                <span className="text-b-2-regular text-gray-200">
-                  {item.category} &middot; {item.size}
-                </span>
-              </div>
-              <Image
-                className="object-contain"
-                src={item.image}
-                alt={item.name}
-                fill
-              />
-            </li>
-          ))}
-        </ul>
-      </section>
+      <h1 className="sr-only">드레스룸</h1>
+      <DressroomContent items={dressroom} />
     </main>
   );
 };

--- a/src/components/atoms/BasicButton.tsx
+++ b/src/components/atoms/BasicButton.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 
 interface Tbutton {
   type?: "submit" | "button";
+  form?: string;
   size: "xs" | "sm" | "md" | "lg";
   color: "primary" | "secondary";
   shadow?: boolean;
@@ -19,6 +20,7 @@ interface Tbutton {
 }
 const BasicButton = ({
   type,
+  form,
   size,
   color = "primary",
   shadow = false,
@@ -59,6 +61,7 @@ const BasicButton = ({
     return (
       <button
         type={type}
+        form={form}
         onClick={onClick}
         disabled={disabled || pending}
         className={`${!disabled ? colorStyle[color] : colorStyle["disabled"]} ${sizeStyle[size]} ${round ? "rounded" : ""} ${shadow ? "shadow-lg" : ""} ${className}`}

--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -1,6 +1,7 @@
 interface TCheckbox {
   id: string;
   children: string;
+  label?: boolean;
   type: "all" | "seperate";
   className?: string;
   checked: boolean;
@@ -8,6 +9,7 @@ interface TCheckbox {
 
 const Checkbox = ({
   id,
+  label = true,
   checked,
   children,
   type,
@@ -19,41 +21,46 @@ const Checkbox = ({
     seperate: "peer-checked:before:text-b-2-semibold",
   };
   return (
-    <label
-      htmlFor={id}
-      tabIndex={1}
-      className={`relative flex cursor-pointer ${className}`}
-    >
+    <>
       <input
         id={id}
-        className={`peer appearance-none`}
+        className={`peer hidden`}
         type="checkbox"
         aria-describedby={`${children} 체크`}
+        aria-label={label ? "" : `${children} 체크`}
         onChange={() => {
           null;
         }}
         checked={checked}
       />
-      <svg
-        width="12"
-        height="9"
-        viewBox="0 0 12 9"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        className={`absolute left-1 top-[30%] text-gray-500 peer-checked:${type === "all" ? "text-white" : "text-blue-700"}`}
+
+      <label
+        htmlFor={id}
+        tabIndex={1}
+        className={`relative flex cursor-pointer ${className}`}
       >
-        <path
-          d="M0.5 4L4.5 8L11.5 0.5"
-          stroke="currentColor"
-          strokeWidth="1.8"
-        />
-      </svg>
-      <span
-        className={`point-cursor before:content[' '] flex select-none items-center text-b-2-regular before:mr-2 before:inline-block before:h-5 before:w-5 peer-checked:text-b-2-semibold peer-checked:after:sr-only peer-checked:after:content-['선택됨'] ${typeStyle[`${type}`]}`}
-      >
-        {children}
-      </span>
-    </label>
+        <svg
+          width="12"
+          height="9"
+          viewBox="0 0 12 9"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className={`absolute left-1 top-[30%] text-gray-500 peer-checked:${type === "all" ? "text-white" : "text-blue-700"}`}
+        >
+          <path
+            d="M0.5 4L4.5 8L11.5 0.5"
+            stroke="currentColor"
+            strokeWidth="1.8"
+          />
+        </svg>
+
+        <span
+          className={`point-cursor before:content[' '] flex select-none items-center text-b-2-regular before:mr-2 before:inline-block before:h-5 before:w-5 peer-checked:text-b-2-semibold peer-checked:after:sr-only peer-checked:after:content-['선택됨'] ${typeStyle[`${type}`]}`}
+        >
+          {label ? children : null}
+        </span>
+      </label>
+    </>
   );
 };
 

--- a/src/components/atoms/ColorButton.tsx
+++ b/src/components/atoms/ColorButton.tsx
@@ -1,0 +1,20 @@
+import { colorPallet } from "@/components/organism/DressroomContent";
+interface Props {
+  color: string;
+  active: boolean;
+  onClick: (color: string) => void;
+}
+
+const ColorButton = ({ color, active, onClick: onChange }: Props) => {
+  return (
+    <button
+      aria-label={`${color} 색상 선택`}
+      type="button"
+      className={`inline-block h-6 w-6 cursor-pointer ${active ? "scale-110" : color !== "white" ? "brightness-75" : ""} ${color === "white" ? "border border-gray-300" : ""}`}
+      style={{ backgroundColor: colorPallet[color] }}
+      onClick={() => onChange(color)}
+    ></button>
+  );
+};
+
+export default ColorButton;

--- a/src/components/atoms/TagButton.tsx
+++ b/src/components/atoms/TagButton.tsx
@@ -5,6 +5,9 @@ interface Ttag {
   color?: "primary" | "secondary";
   disabled?: boolean;
   cancel?: boolean;
+  checkBox?: boolean;
+  id?: string;
+  checked?: boolean;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   children: React.ReactNode;
 }
@@ -13,7 +16,10 @@ const TagButton = ({
   color = "primary",
   disabled,
   cancel,
+  checkBox,
+  id,
   onClick,
+  checked,
   children,
 }: Ttag) => {
   const colorStyle = {
@@ -26,6 +32,7 @@ const TagButton = ({
   if (type) {
     return (
       <button
+        onClick={onClick}
         type={type}
         className={`flex h-8 items-center justify-center rounded-[45px] px-3 py-2 text-b-2-regular ${colorStyle[color]} ${!disabled ? colorStyle[color] : colorStyle["disabled"]}}`}
       >
@@ -44,14 +51,32 @@ const TagButton = ({
           </button>
         </div>
       );
+    } else if (checkBox) {
+      return (
+        <>
+          <input
+            type="checkbox"
+            className="peer hidden"
+            id={id}
+            checked={checked}
+          />
+          <label
+            htmlFor={id}
+            className={`flex h-8 cursor-pointer items-center justify-center rounded-[45px] px-3 py-2 text-b-2-regular peer-checked:bg-black peer-checked:text-white ${colorStyle[color]}} `}
+          >
+            {children}
+          </label>
+        </>
+      );
+    } else {
+      return (
+        <div
+          className={`flex h-8 items-center justify-center rounded-[45px] px-3 py-2 text-b-2-regular ${colorStyle[color]}}`}
+        >
+          {children}
+        </div>
+      );
     }
-    return (
-      <div
-        className={`flex h-8 items-center justify-center rounded-[45px] px-3 py-2 text-b-2-regular ${colorStyle[color]}}`}
-      >
-        {children}
-      </div>
-    );
   }
 };
 export default TagButton;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -12,3 +12,4 @@ export { default as Progressbar } from "./Progressbar";
 export { default as ModalCloseBtn } from "./ModalCloseBtn";
 export { default as ProductCardForStyle } from "./ProductCardForStyle";
 export { default as ResponsiveComponent } from "./ResponsiveComponent";
+export { default as ColorButton } from "./ColorButton";

--- a/src/components/organism/DressroomContent.tsx
+++ b/src/components/organism/DressroomContent.tsx
@@ -1,0 +1,273 @@
+"use client";
+import {
+  BasicButton,
+  Checkbox,
+  ColorButton,
+  TagButton,
+} from "@/components/atoms";
+import { TDressroom } from "@/types/DatabaseTypes";
+import Image from "next/image";
+import { useState } from "react";
+
+const DressroomContent = ({ items }: { items: TDressroom[] }) => {
+  // 추후에 모든 상태가 비어있을 때는 모든 상품 렌더링
+  // 모든 상태가 비어있지 않을 때는 필터링된 상품 렌더링
+  const [seasonState, setSeasonState] = useState<string[]>([]);
+  const [categoryState, setCategoryState] = useState<string[]>([]);
+  const [colorState, setcolorState] = useState<string[]>([]);
+  const [editMode, setEditMode] = useState<boolean>(false);
+  const handleEditMode = () => {
+    setEditMode((prev) => !prev);
+  };
+  const handleSeasonFilter = (season: string) => {
+    setSeasonState((prev) => {
+      if (prev.includes(season)) {
+        return prev.filter((s) => s !== season);
+      } else {
+        return [...prev, season];
+      }
+    });
+  };
+  const handleCategoryFilter = (category: string) => {
+    setCategoryState((prev) => {
+      if (prev.includes(category)) {
+        return prev.filter((c) => c !== category);
+      } else {
+        return [...prev, category];
+      }
+    });
+  };
+  const handleColorFilter = (color: string) => {
+    setcolorState((prev) => {
+      if (prev.includes(color)) {
+        return prev.filter((c) => c !== color);
+      } else {
+        return [...prev, color];
+      }
+    });
+  };
+
+  const [sort, setSort] = useState<string>(sortOptions[0]);
+  const handleSortFilter = (selectedSort: string) => {
+    //
+    setSort(selectedSort);
+  };
+  return (
+    <>
+      <aside className="box-content flex w-[304px] flex-col gap-[64px] pr-[80px]">
+        <div className="flex flex-col gap-[18px]">
+          {/* Season */}
+          <span className="border-b border-gray-400 pb-2 text-b-0-bold">
+            Season
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {Object.keys(seasons).map((season) => (
+              <TagButton
+                type="button"
+                key={season}
+                color={seasonState.includes(season) ? "primary" : "secondary"}
+                onClick={() => handleSeasonFilter(season)}
+              >
+                {seasons[season]}
+              </TagButton>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-col gap-[18px]">
+          {/* Category */}
+          <span className="border-b border-gray-400 pb-2 text-b-0-bold">
+            Category
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {Object.keys(categories).map((category) => (
+              <TagButton
+                type="button"
+                key={category}
+                color={
+                  categoryState.includes(category) ? "primary" : "secondary"
+                }
+                onClick={() => handleCategoryFilter(category)}
+              >
+                {categories[category]}
+              </TagButton>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-col gap-[18px]">
+          {/* Color */}
+          <span className="border-b border-gray-400 pb-2 text-b-0-bold">
+            Color
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {Object.keys(colorPallet).map((color) => (
+              <ColorButton
+                key={color}
+                color={color}
+                active={colorState.includes(color)}
+                onClick={() => handleColorFilter(color)}
+              />
+            ))}
+          </div>
+        </div>
+      </aside>
+      <section className="flex w-full flex-col">
+        <div className="mb-[38px] flex justify-between">
+          {editMode ? (
+            <>
+              {/* Sort */}
+              <div className="flex items-center justify-center gap-2 text-gray-450">
+                <div>
+                  <span className="text-blue-500">3</span> / <span>17</span>개
+                  선택
+                </div>
+                |<button type="button">전체선택</button>
+              </div>
+
+              <div className="flex gap-3">
+                <BasicButton
+                  type="submit"
+                  form="delete-form"
+                  className="px-4"
+                  size="sm"
+                  color="secondary"
+                >
+                  삭제
+                </BasicButton>
+                <BasicButton
+                  type="button"
+                  onClick={handleEditMode}
+                  className="px-4"
+                  size="sm"
+                  color="primary"
+                >
+                  완료
+                </BasicButton>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex gap-3">
+                {sortOptions.map((option) => (
+                  <TagButton
+                    key={option}
+                    type="button"
+                    color={sort === option ? "primary" : "secondary"}
+                    onClick={() => handleSortFilter(option)}
+                  >
+                    {option}
+                  </TagButton>
+                ))}
+              </div>
+              <div className="flex gap-3">
+                <BasicButton
+                  className="px-4"
+                  size="sm"
+                  color="primary"
+                  href="/dressroom/register"
+                >
+                  등록
+                </BasicButton>
+                <BasicButton
+                  type="button"
+                  onClick={handleEditMode}
+                  className="px-4"
+                  size="sm"
+                  color="primary"
+                >
+                  편집
+                </BasicButton>
+              </div>
+            </>
+          )}
+        </div>
+        <ul className="grid w-full grid-cols-5 gap-5">
+          {items.map((item) => (
+            <DressroomItem item={item} editMode={editMode} key={item._id} />
+          ))}
+        </ul>
+      </section>
+    </>
+  );
+};
+export default DressroomContent;
+const DressroomItem = ({
+  item,
+  editMode,
+}: {
+  item: TDressroom;
+  editMode: boolean;
+}) => {
+  return (
+    <li className="group relative block aspect-square shadow-lg" key={item._id}>
+      {editMode ? (
+        <form id="delete-form">
+          <Checkbox
+            className="absolute left-2 top-2 z-40"
+            label={false}
+            type="all"
+            checked={true}
+            id={item._id}
+          >
+            {item.name}
+          </Checkbox>
+        </form>
+      ) : (
+        ""
+      )}
+      <div className="absolute inset-0 z-10 flex flex-col justify-end bg-hover-gradient px-5 pb-4 text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+        <span className="truncate text-b-2-bold">{item.name}</span>
+        <span className="mb-3 text-b-3-regular text-gray-200">
+          {item.price}원
+        </span>
+        <span className="text-b-2-regular text-gray-200">
+          {item.category} &middot; {item.size}
+        </span>
+      </div>
+      <Image className="object-contain" src={item.image} alt={item.name} fill />
+    </li>
+  );
+};
+export const colorPallet: { [key: string]: string } = {
+  white: "#FFFFFF",
+  pink: "#FF89BB",
+  red: "#FF685F",
+  orange: "#FF9F46",
+  yellow: "#FFE03C",
+  green: "#74D472",
+  blue: "#79CAE4",
+  black: "#000000",
+  gray: "#818181",
+  beige: "#F6E9C9",
+  brown: "#8D7360",
+  kaki: "#4B734A",
+  navy: "#3C72C2",
+  purple: "#AA78DD",
+};
+export const seasons: { [key: string]: string } = {
+  "spring-autumn": "봄/가을",
+  summer: "여름",
+  winter: "겨울",
+  "all-season": "사계절",
+};
+export const categories: { [key: string]: string } = {
+  beauty: "뷰티",
+  shoes: "신발",
+  top: "상의",
+  pants: "바지",
+  skirt: "원피스/스커트",
+  bag: "가방",
+  accessory: "패션소품",
+  sports: "스포츠/레저",
+  life: "디지털/라이프",
+  outlet: "아울렛",
+  boutique: "부티크",
+  kids: "키즈",
+  earth: "어스",
+};
+export const sortOptions = [
+  "최신순",
+  "업로드순",
+  "가다나순",
+  "낮은 가격순",
+  "높은 가격순",
+];

--- a/src/components/organism/index.ts
+++ b/src/components/organism/index.ts
@@ -2,3 +2,4 @@ export { default as RecommendStyleByItemForDesktop } from "./RecommendStyleByIte
 export { default as RecommendStyleByItemForMobile } from "./RecommendStyleByItemForMobile";
 export { default as StyleModal } from "./modal/StyleModal";
 export { default as DRregisterModal } from "./modal/DRregisterModal";
+export { default as DressroomContent } from "./DressroomContent";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이슈번호를 작성해주세요.

- #26 #27 #28 #80

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- puppeteer를 활용한 웹스크래핑 구현 완료
- 사용자 인터렉션이 많은 페이지라 client로 Dressroom 구현
- filter 및 sort, 편집 UI 구현

## 이슈
- 시멘틱이라 생각했던 checkbox, radio로 생각했던 필터와 정렬, 그러나 상태에 담아 반영할 것이라 button이 맞는 선택으로 판단, 수정
- 누군가 만들어 놓은 checkbox 컴포넌트 호환 이슈로 양쪽 다 깨짐 없이 잘 나오게끔 수정 필요
- 현재 웹스크래핑의 로딩은 버튼에 스피너로 사용자에게 알리고 있지만 계획대로 화면 전체에 나타날 suspense 컴포넌트를 만들어 올려야함
- 
## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 필터와 정렬을 서버에서 할지, client에서 할지 고민중
- 사실 필터 초기 상태는 모두 true인데 그러면 UI가 헷갈릴 수 있어서 초기 렌더링 시에는 필터링 없이 모두 불러와야함. -> 이러면 어차피 다 불러온거 무한 스크롤이나 pagenation이 안들어간다면 클라이언트에서 필터, 정렬을 구현하는게 맞음. 근데 또 사실 페이지를 나눠서 데이터 패치하는 양의 부담을 줄여야하는 것도 사실(NoSQL인데 시간차가 클까...?).
- 편집기능 구현 전략 : 선택 후 form으로 서버액션을 보낼 예정인데, 사용자에게 진짜 삭제할지 묻고 복구할 수 있는 트랜젝션 롤백을 구현한다면 더욱 사용자 친화적인 ux를 제공할 수 있음(거의 포트폴리오에 언급할만한 내용)
